### PR TITLE
Only Extracting Public Key for RSA Certificates

### DIFF
--- a/js/x509.js
+++ b/js/x509.js
@@ -1272,9 +1272,6 @@ pki.certificateFromAsn1 = function(obj, computeHash) {
 
   // get oid
   var oid = asn1.derToOid(capture.publicKeyOid);
-  if(oid !== pki.oids['rsaEncryption']) {
-    throw new Error('Cannot read public key. OID is not RSA.');
-  }
 
   // create certificate
   var cert = pki.createCertificate();
@@ -1392,7 +1389,9 @@ pki.certificateFromAsn1 = function(obj, computeHash) {
   }
 
   // convert RSA public key from ASN.1
-  cert.publicKey = pki.publicKeyFromAsn1(capture.subjectPublicKeyInfo);
+  if(oid === pki.oids['rsaEncryption']) {
+    cert.publicKey = pki.publicKeyFromAsn1(capture.subjectPublicKeyInfo);
+  }
 
   return cert;
 };


### PR DESCRIPTION
We only want to parse certificate metadata, so we don't care if we can't extract the public key because the certificate isn't RSA.

This change only extracts the public key if the certificate is RSA, and silently succeeds otherwise.
